### PR TITLE
Fixes issue #2 with downtime being NaN

### DIFF
--- a/lib/watchmen.js
+++ b/lib/watchmen.js
@@ -293,7 +293,7 @@ function query_url(url_conf, redis, request, config, callback){
 				
 				//service was down and now it is up again!
 				if ((status_data != null) && (status_data.status == 0)){
-					var down_time = (new Date() - new Date(status_data.down_timestamp)) / 1000;
+					var down_time = Math.round((Date.now() - status_data.down_timestamp) / 1000);
 					var info = url_info + ' is back!. Downtime: ' + down_time + ' seconds';
 					if (config.notifications.Enabled){
 						sendEmail(


### PR DESCRIPTION
The timestamp comes back from redis as a string which new Date() does not accept. This change makes it report the number of seconds downtime correctly.
