### PR TITLE
Make headers customizable

### DIFF
--- a/lib/ping_services/http.js
+++ b/lib/ping_services/http.js
@@ -42,6 +42,10 @@ function ping (service, callback){
     method = "HEAD";
   }
 
+  for (var key in service.headers) {
+    headers[key] = service.headers[key];
+  }
+
   var options = {
     port: service.host.port,
     host: service.host.host,


### PR DESCRIPTION
Hi,

I saw there is a `headers` variable which is defined and initialized with `Content-Type` and `Content-Length`, but is unused. I presume this was a mistake, so I fixed it.

I also needed to add a custom header, so I added an ability to specify headers in service configuration alongside the url and method.
