### PR TITLE
Redis config have an security issue

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1,3 +1,4 @@
+bind 127.0.0.1
 port 1216
 daemonize yes
 dbfilename watchmen.rdb


### PR DESCRIPTION
Redis config make redis-server opened to world from server. It need to bind only to localhost.

Added: bind 127.0.0.1