### PR TITLE
Docker and docker-compose support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+screenshots
+logs/
+.monitor
+.DS_Store
+node_modules/
+*.rdb
+.idea/
+webserver/public/bower_components/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:0.10
 WORKDIR /watchmen
 
 # Installs dependencies first
-ADD package.json bower.json /watchmen/
+ADD package.json bower.json .bowerrc /watchmen/
 RUN set -x \
  && npm install -g bower \
  && npm install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:0.10
+
+WORKDIR /watchmen
+
+# Installs dependencies first
+ADD package.json bower.json /watchmen/
+RUN set -x \
+ && npm install -g bower \
+ && npm install \
+ && bower install --allow-root
+
+# Add all the project
+ADD . /watchmen
+
+ENV WATCHMEN_WEB_PORT=3000
+
+EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -374,6 +374,23 @@ sh populate-dummy-data-30days.sh
 etc..
 
 
+## Running with docker
+
+To run with docker, make sure you have docker-compose installed: https://docs.docker.com/compose/install/
+
+Also, have a docker host running. A good way is using docker-machine with a local VM: https://docs.docker.com/machine/get-started/
+
+To build and run Watchmen, run the following:
+
+```
+docker-compose build
+docker-compose up
+```
+
+After this Watchmen webserver will be running and exposed in the port 3000 of the docker host.
+
+To configure, please look `docker-compose.yml` and `docker-compose.env`.
+
 ## Tests
 
 ```sh

--- a/config/storage.js
+++ b/config/storage.js
@@ -5,7 +5,7 @@ module.exports = {
     options : {
       'redis' : {
         port: process.env.WATCHMEN_REDIS_PORT_PRODUCTION || 1216,
-        host: '127.0.0.1',
+        host: process.env.WATCHMEN_REDIS_ADDR_PRODUCTION || '127.0.0.1',
         db: process.env.WATCHMEN_REDIS_DB_PRODUCTION || 1
       }
     }
@@ -16,7 +16,7 @@ module.exports = {
     options : {
       'redis' : {
         port: process.env.WATCHMEN_REDIS_PORT_DEVELOPMENT || 1216,
-        host: '127.0.0.1',
+        host: process.env.WATCHMEN_REDIS_ADDR_DEVELOPMENT || '127.0.0.1',
         db: process.env.WATCHMEN_REDIS_DB_DEVELOPMENT || 2
       }
     }
@@ -27,7 +27,7 @@ module.exports = {
     options : {
       'redis' : {
         port: process.env.WATCHMEN_REDIS_PORT_TEST || 6666,
-        host: '127.0.0.1',
+        host: process.env.WATCHMEN_REDIS_ADDR_TEST || '127.0.0.1',
         db: process.env.WATCHMEN_REDIS_DB_TEST || 1
       }
     }

--- a/docker-compose.env
+++ b/docker-compose.env
@@ -1,0 +1,19 @@
+# Basic configuration  
+WATCHMEN_BASE_URL='http://watchmen.letsnode.com:3000'
+WATCHMEN_WEB_PORT=3000
+WATCHMEN_ADMINS='luis.armandob@gmail.com'
+WATCHMEN_GOOGLE_ANALYTICS_ID='your-GA-ID'
+
+# Google OAuth configuration
+WATCHMEN_GOOGLE_CLIENT_ID=''
+WATCHMEN_GOOGLE_CLIENT_SECRET=''
+
+# Ignore Unauthorized SSL certificates
+NODE_TLS_REJECT_UNAUTHORIZED=0
+
+# Run in production mode
+NODE_ENV=production
+
+# Use redis service link, DNS entry
+WATCHMEN_REDIS_PORT_PRODUCTION=6379
+WATCHMEN_REDIS_ADDR_PRODUCTION=redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+redis:
+    image: redis:2
+    ports:
+        - "6379"
+    # expose db in the host /data dir, make sure to create and set permissions for this folder
+    volumes:
+        - /data:/data
+watchmenpopulate:
+    # populates with stub data of real services
+    build: ./
+    links:
+        - redis
+    command: node scripts/data-load/populate-services-from-fixtures.js -r -e production
+    env_file: docker-compose.env
+watchmenweb:
+    build: ./
+    ports:
+        - "3000:3000"
+    links:
+        - redis
+    command: node run-web-server.js
+    env_file: docker-compose.env
+watchmenserver:
+    build: ./
+    links:
+        - redis
+    command: node run-monitor-server.js
+    env_file: docker-compose.env

--- a/scripts/data-load/populate-services-from-fixtures.js
+++ b/scripts/data-load/populate-services-from-fixtures.js
@@ -12,7 +12,10 @@ function run(program){
     return;
   }
 
-  if (program.real) {
+  if (program.file) {
+    console.log('Populating from ' + program.file);
+    services = require(program.file);
+  } else if (program.real) {
     console.log('Populating real services...');
     services = require('../../test/fixtures/real-services');
   } else {
@@ -34,6 +37,7 @@ function run(program){
 var program = require('commander');
 program
     .option('-r, --real', 'User real data')
+    .option('-f, --file [file]', 'Fixture file')
     .option('-e, --env [env]', 'Storage environment key')
     .option('-s, --number-services [numberServices]', 'Number of services')
     .parse(process.argv);


### PR DESCRIPTION
I am adding a `Dockerfile` to build a docker image of WatchMen. I also added an automated build to docker hub under my user: https://hub.docker.com/r/labianchin/watchmen/. @iloire, I think you should create an entry on your name.

This also adds a `docker-compose.yml`. I hope this will really make easy for users to get Watchmen running. It runs 4 services:
- A redis instance
- `monitor-server`
- `web-server`
- Data population, this will use the data from `populate-services-from-fixtures.js` to add some real services

If users want to customize the way they run, they can change `docker-compose.yml` or `docker-compose.env`. Ideally both of this files will not depend in this project, it would only depend on the docker image. To do that we will later need to change the `build: ./` to something like `image: user/watchmen`.