### PR TITLE
Add support for node foreman

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+monitor: node run-monitor-server.js
+web: node run-web-server.js

--- a/README.md
+++ b/README.md
@@ -93,6 +93,33 @@ Server list:
 
 ![List of pm2 services](https://github.com/iloire/watchmen/raw/master/screenshots/pm2-01.png)
 
+
+## Managing with node-foreman
+
+`node-foreman` can be used to run the monitor and web server as an Upstart
+service. On Ubuntu systems, this allows the usage of `service watchmen start`.
+
+Watchmen already include a `Procfile` so you can also manage with `nf`.
+
+```
+$ npm install -g foreman
+$ nf start
+```
+
+To export as an Upstart script using the environment variables in a `.env` file:
+
+```
+$ PATH="/home/user/.nvm/versions/v5.1.0/bin:$PATH" nf export -o /etc/init -a watchmen
+```
+
+You can run this without the `-o /etc/init` flag and move the files to this
+directory (or the appropriate Upstart) directory yourself. Make sure you have
+the correct path to the `node` bin, you can find out with `which node`.
+
+More documentation on `node-foreman`:
+
+https://github.com/strongloop/node-foreman
+
 ## Configuration
 
 Config is set through ``env`` variables.


### PR DESCRIPTION
I added a `Procfile` so the monitor and web server can be managed similarly to `pm2`. This uses `node-foreman` which is similar to Foreman in the Ruby world.

The benefit of this is easily exporting to an Upstart script with managed environment variables. This is described in my changes to the README.

At work, we use this to start watchmen up when the server boots and manage configuration/plugin changes through `sudo service watchmen restart` (much easier! 😍)