### PR TITLE
Use `path.join` for constructing path to `package.json`

### DIFF
--- a/lib/plugin-loader.js
+++ b/lib/plugin-loader.js
@@ -1,7 +1,9 @@
+var path = require('path');
+
 exports = module.exports = (function(){
 
   var PREFIX_PING_PLUGIN = 'watchmen-plugin-';
-  var pkgJson = require(__dirname + '../../package.json');
+  var pkgJson = require(path.join(__dirname, '/../package.json'));
 
   return {
 

--- a/webserver/routes/api-ping-plugins-route.js
+++ b/webserver/routes/api-ping-plugins-route.js
@@ -1,11 +1,12 @@
 var express = require('express');
+var path = require('path');
 
 exports = module.exports.getRoutes = function (){
 
   var PREFIX_PING_PLUGIN = 'watchmen-ping-';
 
   var router = express.Router();
-  var pkgJson = require(__dirname + '../../../package.json');
+  var pkgJson = require(path.join(__dirname, '/../../package.json'));
 
   function getOptions(dep){
       try {


### PR DESCRIPTION
Using `Node.js v5.7` I'm receiving the following error when trying to run the app:

```
Using storage env:  development
module.js:341
    throw err;
    ^

Error: Cannot find module '/private/tmp/watchmen/webserver/routes../../../package.json'
    at Function.Module._resolveFilename (module.js:339:15)
    at Function.Module._load (module.js:290:25)
    at Module.require (module.js:367:17)
    at require (internal/module.js:16:19)
    at Object.module.exports.getRoutes (/private/tmp/watchmen/webserver/routes/api-ping-plugins-route.js:8:17)
    at module.exports (/private/tmp/watchmen/webserver/app.js:42:35)
    at Object.<anonymous> (/private/tmp/watchmen/run-web-server.js:23:11)
    at Module._compile (module.js:413:34)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)
```

It appears as if joining the path using `+` has a different outcome, I'd say it's better in any case to join it using the `path`-module.