### PR TITLE
Fixed redis sorted set member uniqueness (zadd)

### DIFF
--- a/lib/storage/providers/redis.js
+++ b/lib/storage/providers/redis.js
@@ -210,7 +210,9 @@ StorageRedis.prototype.getServiceOutagesSince = function (service, timestamp, ca
  */
 
 StorageRedis.prototype.saveLatency = function (service, timestamp, elapsed, callback) {
-  this.redis.zadd(service.id + ':' + LATENCY_KEY_SUFIX, timestamp, elapsed, callback);
+  //ZADD set_name score member
+  //member should be unique, that's why it is timestamp:elapsed
+  this.redis.zadd(service.id + ':' + LATENCY_KEY_SUFIX, timestamp, timestamp+':'+elapsed, callback);
 };
 
 /**
@@ -283,9 +285,14 @@ function parseLatencyDataFromZset(zset) {
   var accLatency = 0;
   for (var i = 0; i < zset.length; i++) {
     if (i % 2 === 0) { // odd
-      currentObj = {l: +zset[i]}; // latency
-      if (!isNaN(zset[i]) && zset[i] > 0) { // valid positive numbers
-        accLatency += (+zset[i]);
+      var lat = zset[i];
+      //backward compatibility: only split timestamp:score if found this format
+      if(lat.indexOf(':')!==-1){
+        lat = lat.split(':')[1];
+      }
+      currentObj = {l: +lat}; // latency
+      if (!isNaN(lat) && lat > 0) { // valid positive numbers
+        accLatency += (+lat);
       }
     } else {
       currentObj.t = +zset[i]; // timestamp

--- a/test/test-report.js
+++ b/test/test-report.js
@@ -188,10 +188,8 @@ describe('reporting', function () {
         var data = [
           {timestamp: INITIAL_TIME, latency: 100},
           {timestamp: INITIAL_TIME + 1.1 * DAY, latency: 200},
-
-          {timestamp: INITIAL_TIME + 2 * DAY, latency: 400},
-
-          {timestamp: INITIAL_TIME + 3 * DAY, latency: 900},
+          {timestamp: INITIAL_TIME + 2.1 * DAY, latency: 400},
+          {timestamp: INITIAL_TIME + 3.1 * DAY, latency: 900},
           {timestamp: INITIAL_TIME + 3.5 * DAY, latency: 1100}
         ];
 


### PR DESCRIPTION
### The problem:
Redis sorted set data type have 2 main properties:
* range (integer - sorted)
* member (string - unique)

When watchmen adds a new latency measurement to redis the following command is used:
```bash
ZADD event range member
```
Currently watchmen is using the timestamp as the range (because it is automatically sorted) and the elapsed time as the member. For a measurement of 20ms on 1/1/00 00:00:
```bash
ZADD event 946684800000 20
```
The issue happens when we have another measurement WITH THE SAME ELAPSED TIME (member):
```bash
ZADD event 94665000000 20
```
The fist record will be overwritten because the member value is the same! That's why sometimes the charts misses some data, like this one taken from watchmen's live example:

![watchmen](https://cloud.githubusercontent.com/assets/1678020/13900322/5160254e-ede2-11e5-8b5e-6759b59cba03.png)

### The solution:
When adding a new latency we must change the member to "timestamp:elapsed" (thus making sure the member is unique). Example:
```bash
ZADD event 94665000000 94665000000:20
```
Now every time we need to read the latency from redis we must to remove the "timestamp:" part and keep the elapsed time. I also added I check for the ":" character to make sure the solution would still work for the older latency format (added a new test for this check)!