### PR TITLE
Use config abstraction instead of calling process.env directly

### DIFF
--- a/webserver/routes/web-auth-route.js
+++ b/webserver/routes/web-auth-route.js
@@ -14,7 +14,7 @@ module.exports = (function (){
   }
 
   function isAdmin(email){
-    var admins = (process.env.WATCHMEN_ADMINS || '').split(',').map(function(email){ return email.trim (); });
+    var admins = (config.admins || '').split(',').map(function(email){ return email.trim (); });
     return admins.indexOf(email)>-1;
   }
 


### PR DESCRIPTION
It's a small thing, but since the abstraction is there it's better to use it.