### PR TITLE
feat: Implement Tags feature

### DIFF
--- a/lib/storage/providers/redis.js
+++ b/lib/storage/providers/redis.js
@@ -1,6 +1,3 @@
-var util = require('util');
-var async = require('async');
-var debug = require('debug')('redis-storage');
 var redis = require("redis");
 var shortid = require('shortid');
 var aggregator = require('../../aggregator');
@@ -8,6 +5,7 @@ var connectRedis = require('connect-redis');
 
 var SERVICE_KEY_SUFIX = "service";
 var SERVICES_KEY_SUFIX = "service";
+var TAGS_KEY_SUFIX = "tags";
 var LATENCY_KEY_SUFIX = "latency";
 var CURRENT_OUTAGE_KEY_SUFIX = "outages:current";
 var OUTAGES_KEY_SUFIX = "outages";
@@ -19,7 +17,33 @@ function StorageRedis(options) {
   this.redis.select(this.options.db || 0);
 }
 
+/**
+ * Remove duplicates, change the string of tags to an array,
+ * and updates the main list of tags
+ */
+function handleTags(service, multi) {
+
+    var tags = [];
+    if (service.tags) {
+        tags = service.tags.split(",");
+        for (var i = 0; i < tags.length; i++) {
+            multi.sadd(TAGS_KEY_SUFIX, tags[i].trim());
+        }
+
+        // prevent duplicate tags
+        var finalTags = [];
+        tags.forEach(function(tag) {
+            if (!finalTags.includes(tag)) finalTags.push(tag)
+        });
+        service.tags = finalTags;
+    } else {
+        service.tags = []
+    }
+    return service;
+}
+
 exports = module.exports = StorageRedis;
+
 
 
 /**
@@ -33,8 +57,12 @@ StorageRedis.prototype.addService = function (service, callback) {
   service.id = id;
   service.created = +new Date();
   var multi = this.redis.multi();
-  multi.set(SERVICE_KEY_SUFIX + ':' + id, JSON.stringify(service));
   multi.sadd(SERVICES_KEY_SUFIX, id);
+
+  handleTags(service, multi);
+
+  multi.set(SERVICE_KEY_SUFIX + ':' + id, JSON.stringify(service));
+
   multi.exec(function (err) {
     callback(err, id);
   });
@@ -50,6 +78,9 @@ StorageRedis.prototype.updateService = function (service, callback) {
   var self = this;
   var multi = this.redis.multi();
   multi.set(SERVICE_KEY_SUFIX + ':' + service.id, JSON.stringify(service));
+
+  handleTags(service, multi);
+
   multi.exec(function (err) {
     if (err) {
       return callback(err);
@@ -118,6 +149,18 @@ StorageRedis.prototype.getServices = function (options, callback) {
       return callback(err);
     }
 
+    function filterByTag(service) {
+        if (!options.tags || !options.tags.length) return true;
+
+        if (!(options.tags instanceof Array)) {
+          return service.tags.includes(options.tags);
+        }
+        for (var i = 0; i < service.tags.length; i++) {
+          if (options.tags.includes(service.tags[i])) return true;
+        }
+        return false;
+    }
+
     var multi = self.redis.multi();
     for (var i = 0; i < ids.length; i++) {
       multi.get(SERVICE_KEY_SUFIX + ':' + ids[i]);
@@ -125,7 +168,7 @@ StorageRedis.prototype.getServices = function (options, callback) {
     multi.exec(function (err, services) {
       callback(err, services.map(function (service) {
         return JSON.parse(service);
-      }));
+      }).filter(filterByTag));
     });
   });
 };
@@ -252,6 +295,14 @@ StorageRedis.prototype.getLatencySince = function (service, timestamp, aggregate
   });
 };
 
+StorageRedis.prototype.getTags = function(callback) {
+    var self = this;
+    this.redis.smembers(TAGS_KEY_SUFIX, function (err, tags) {
+        return callback(err, tags);
+    });
+
+}
+
 StorageRedis.prototype.resetOutageFailureCount = function (service, cb) {
   this.redis.del(service.id + ':' + FAILURE_COUNT_SUFIX, cb);
 };
@@ -275,6 +326,7 @@ StorageRedis.prototype.getSessionStore = function (session, options) {
     client: this.redis
   });
 };
+
 
 /**
  * Converts ["124", "1428222697560", "123", "1428222692345"]

--- a/lib/storage/providers/redis.js
+++ b/lib/storage/providers/redis.js
@@ -22,23 +22,25 @@ function StorageRedis(options) {
  * and updates the main list of tags
  */
 function handleTags(service, multi) {
-
-    var tags = [];
     if (service.tags) {
-        tags = service.tags.split(",");
-        for (var i = 0; i < tags.length; i++) {
-            multi.sadd(TAGS_KEY_SUFIX, tags[i].trim());
+        if (!(service.tags instanceof Array)) {
+            service.tags = service.tags.split(",");
         }
-
-        // prevent duplicate tags
-        var finalTags = [];
-        tags.forEach(function(tag) {
-            if (!finalTags.includes(tag)) finalTags.push(tag)
-        });
-        service.tags = finalTags;
     } else {
         service.tags = []
     }
+
+    service.tags.forEach(function(tag) {
+        multi.sadd(TAGS_KEY_SUFIX, tag.trim());
+    });
+
+    // prevent duplicate tags
+    var finalTags = [];
+    service.tags.forEach(function (tag) {
+        var t = tag.trim();
+        if (!finalTags.includes(t)) finalTags.push(t)
+    });
+    service.tags = finalTags;
     return service;
 }
 
@@ -59,7 +61,7 @@ StorageRedis.prototype.addService = function (service, callback) {
   var multi = this.redis.multi();
   multi.sadd(SERVICES_KEY_SUFIX, id);
 
-  handleTags(service, multi);
+  service = handleTags(service, multi);
 
   multi.set(SERVICE_KEY_SUFIX + ':' + id, JSON.stringify(service));
 

--- a/test/fixtures/dummy-services.js
+++ b/test/fixtures/dummy-services.js
@@ -11,6 +11,15 @@ exports = module.exports = (function(){
     }
   }
 
+  function getRandomTags() {
+    var tags = [];
+    var size = faker.random.number(3);
+    for (var i = 0; i < size; i++) {
+      tags.push(faker.random.array_element(['prod', 'dev', 'remote', 'office2']))
+    }
+    return tags;
+  }
+
   function generateDummyService (i){
     return {
       name: getRandomName(false),
@@ -20,7 +29,8 @@ exports = module.exports = (function(){
       port: 443,
       timeout: 10000,
       warningThreshold: 3000,
-      pingServiceName: 'http-head'
+      pingServiceName: 'http-head',
+      tags: getRandomTags()
     };
   }
 

--- a/test/test-report.js
+++ b/test/test-report.js
@@ -49,7 +49,7 @@ describe('reporting', function () {
 
     reporter = new reportService(storage);
 
-    servicesFixtures = dummyServiceGenerator.generate(1);
+    var servicesFixtures = dummyServiceGenerator.generate(1);
 
     storage.flush_database(function () {
 
@@ -197,11 +197,12 @@ describe('reporting', function () {
           clock.tick(4 * HOUR);
           reporter.getService(services[0].id, function (err, data) {
             assert.ifError(err);
-            assert.equal(data.status.lastWeek.latency.list.length, 4);
-            assert.equal(data.status.lastWeek.latency.list[0].l, 1000);
-            assert.equal(data.status.lastWeek.latency.list[1].l, 400);
-            assert.equal(data.status.lastWeek.latency.list[2].l, 200);
-            assert.equal(data.status.lastWeek.latency.list[3].l, 100);
+            assert.equal(data.status.lastWeek.latency.list.length, 5);
+            assert.equal(data.status.lastWeek.latency.list[0].l, 1100);
+            assert.equal(data.status.lastWeek.latency.list[1].l, 900);
+            assert.equal(data.status.lastWeek.latency.list[2].l, 400);
+            assert.equal(data.status.lastWeek.latency.list[3].l, 200);
+            assert.equal(data.status.lastWeek.latency.list[4].l, 100);
             done();
           });
         });

--- a/test/test-storage-redis.js
+++ b/test/test-storage-redis.js
@@ -32,13 +32,14 @@ describe('redis storage', function(){
   describe('services', function(){
     it('should save and retrieve service object', function(done) {
       var newService = {
-        interval: 1000
+        interval: 1000,
+        tags: 'tag1, tag2'
       };
       redisStorage.addService(newService, function(err, id){
         redisStorage.getService(id, function(err, service) {
           assert.equal(service.id, id);
           assert.equal(service.created, INITIAL_TIME);
-          assert.equal(service.interval, 1000);
+          assert.deepEqual(service.tags, [ 'tag1' , 'tag2' ]);
           done();
         });
       });
@@ -46,15 +47,19 @@ describe('redis storage', function(){
 
     it('should update service', function(done) {
       var newService = {
-        interval: 1000
+        interval: 1000,
+        tags: ['tag1', 'tag2', 'tag1']
       };
       redisStorage.addService(newService, function(err, id){
         redisStorage.getService(id, function(err, service) {
           assert.equal(service.id, id);
           assert.equal(service.interval, 1000);
+          assert.deepEqual(service.tags, [ 'tag1' , 'tag2' ]);
           service.interval = 2000;
+          service.tags.push('tag3')
           redisStorage.updateService(service, function(err, service) {
             assert.equal(service.interval, 2000);
+            assert.deepEqual(service.tags, [ 'tag1' , 'tag2', 'tag3' ]);
             done();
           });
         });

--- a/webserver/public/js/controllers/service-add.js
+++ b/webserver/public/js/controllers/service-add.js
@@ -29,6 +29,7 @@
       $scope.service.failuresToBeOutage = 1;
       $scope.service.port = 80;
       $scope.service.pingServiceName = 'http-head';
+      $scope.service.tags = '';
 
       $scope.save = function () {
 

--- a/webserver/public/js/controllers/services-list.js
+++ b/webserver/public/js/controllers/services-list.js
@@ -14,6 +14,7 @@
           $timeout,
           Report,
           Service,
+          Tags,
           usSpinnerService,
           ngTableUtils
       ) {
@@ -33,7 +34,9 @@
 
         function reload(doneCb, errorHandler) {
           Report.clearCache();
-          $scope.services = Report.query(function (services) {
+          $scope.services = Report.query({
+              tags: $scope.currentTags
+          }, function (services) {
             $scope[key] = services;
             $scope.tableParams.reload();
 
@@ -41,6 +44,11 @@
             transition.loaded();
             doneCb();
           }, errorHandler);
+
+          Tags.query(function(tags) {
+            $scope.tags = tags;
+          })
+
         }
 
         var transition = {
@@ -57,6 +65,7 @@
         var key = 'tableServicesData';
         $scope[key] = [];
         $scope.tableParams = ngTableUtils.createngTableParams(key, $scope, $filter);
+        $scope.currentTags = [];
 
         var filterToMeCheckboxIsPresent = document.getElementById('filterRestrictedToMe');
         if (filterToMeCheckboxIsPresent && window.localStorage) {
@@ -104,6 +113,29 @@
               });
             });
           }
+        };
+
+          /**
+           * Defines if a tag is currently active
+           * @param tag
+           * @returns {boolean}
+           */
+        $scope.isActiveTag = function(tag) {
+          return $scope.currentTags.includes(tag);
+        };
+
+        $scope.toggleTag = function(tag) {
+          if ($scope.currentTags.includes(tag)) {
+            $scope.currentTags = $scope.currentTags.filter(function(curTag) {
+              return curTag !== tag;
+            })
+          } else {
+            $scope.currentTags.push(tag);
+          }
+          reload(function () {
+          }, function () {
+            $scope.errorLoadingServices = "Error loading data from remote server";
+          });
         };
 
         reload(scheduleNextTick, loadServicesErrHandler);

--- a/webserver/public/js/factories.js
+++ b/webserver/public/js/factories.js
@@ -46,6 +46,16 @@
         });
   });
 
+  factories.factory('Tags', function($http) {
+    return {
+      query: function(callback) {
+        return $http.get('/api/tags').then(function(data) {
+          callback(data.data);
+        });
+      }
+    }
+  });
+
   factories.factory('PingPlugins', function ($resource, $cacheFactory) {
     pingPluginsCache = $cacheFactory('PingPlugins');
     return $resource('/api/plugins/:id',

--- a/webserver/routes/api-report-route.js
+++ b/webserver/routes/api-report-route.js
@@ -52,7 +52,7 @@ module.exports.getRoutes = function (storage){
    */
 
   router.get('/services', function(req, res){
-    reporter.getServices({}, function (err, serviceReports){
+    reporter.getServices(req.query, function (err, serviceReports){
       if (err) {
         console.error(err);
         return res.status(500).json({ error: err });

--- a/webserver/routes/api-service-route.js
+++ b/webserver/routes/api-service-route.js
@@ -168,5 +168,19 @@ module.exports.getRoutes = function (storage) {
     });
   });
 
+  /**
+   * Load tags
+   *
+   */
+  router.get('/tags', requireAdmin, function (req, res) {
+      storage.getTags(function (err, tags) {
+          if (err) {
+              console.error(err);
+              return res.status(500).json({error: err});
+          }
+          res.json(tags);
+      });
+  });
+
   return router;
 };

--- a/webserver/routes/api-service-route.js
+++ b/webserver/routes/api-service-route.js
@@ -1,6 +1,4 @@
-var moment = require('moment');
 var express = require('express');
-var debug = require('debug')('service-route');
 var serviceValidator = require('./../../lib/service-validator');
 var accessFilter = require('./../../lib/service-access-filter');
 var config = require('../../config/web');

--- a/webserver/views/service-edit.html
+++ b/webserver/views/service-edit.html
@@ -86,16 +86,23 @@
             <div class="form-group">
                 <label for="service-restrictedTo" class="col-sm-2 control-label">Restricted to</label>
                 <div class="col-sm-6">
-                    <input type="text" ng-model="service.restrictedTo" type="checkbox" class="form-control" id="service-restrictedTo" placeholder="myemail@mydomain.com, admin@myotherdomain.com">
+                    <input ng-model="service.restrictedTo" class="form-control" id="service-restrictedTo" placeholder="myemail@mydomain.com, admin@myotherdomain.com">
                 </div>
                 <div class="descr col-sm-4">List of restricted emails to have access to this service stats</div>
             </div>
             <div class="form-group">
                 <label for="service-alertTo" class="col-sm-2 control-label">Alert to</label>
                 <div class="col-sm-6">
-                    <input type="text" ng-model="service.alertTo" type="checkbox" class="form-control" id="service-alertTo" placeholder="myemail@mydomain.com, admin@myotherdomain.com">
+                    <input ng-model="service.alertTo" class="form-control" id="service-alertTo" placeholder="myemail@mydomain.com, admin@myotherdomain.com">
                 </div>
                 <div class="descr col-sm-4">List of emails to alert to</div>
+            </div>
+            <div class="form-group">
+                <label for="service-alertTo" class="col-sm-2 control-label">Tags</label>
+                <div class="col-sm-6">
+                    <input ng-model="service.tags" class="form-control" id="service-tags" placeholder="production, develop, apache, nginx">
+                </div>
+                <div class="descr col-sm-4">List of tags to associate this service</div>
             </div>
             <div class="form-group">
                 <div class="col-sm-offset-2 col-sm-10">

--- a/webserver/views/service-list.html
+++ b/webserver/views/service-list.html
@@ -4,7 +4,6 @@
     <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
     <span>{{errorLoadingServices}}</span>
 </div>
-
 <div class="container-fluid" ng-show="!loading">
     <div class="row">
         <div class="filter-container">
@@ -22,6 +21,17 @@
             <% } else {%>
             <input ng-model="query" class="query form-control" placeholder="filter by host name"/>
             <% } %>
+            <div class="row">
+                <div class="col-md-10">
+                    <div class="btn-group">
+                        <button ng-repeat="tag in tags"
+                                type="button"
+                                class="btn btn-default"
+                                ng-class={'btn-primary':isActiveTag(tag)}
+                                ng-click="toggleTag(tag)">{{ tag }}</button>
+                    </div>
+                </div>
+            </div>
         </div>
 
         <table ng-table="tableParams" class="table-services table sorted table-striped table-condensed">


### PR DESCRIPTION
This implement a basic tag feature.

All tags are stored in a separate key in redis, like the services id.

The `/api/report/services` method accept a query param with tags to filter the services.

TODO:

- [x] Custom tags per service
- [x] Filter services by tags
- [ ] Improve the appearance
- [ ] Add tags when specific conditions mets, like outages.

ref #56 